### PR TITLE
修改 dp 实现，部分测试用例不通过

### DIFF
--- a/docs/topics/algorthimn/longestCommonSequence.md
+++ b/docs/topics/algorthimn/longestCommonSequence.md
@@ -6,7 +6,7 @@ function longestCommonSequence(s1, s2) {
   const dp = [];
 
   for (let i = 0; i < s1.length + 1; i++) {
-    dp[i] = Array(s2.length).fill(0);
+    dp[i] = Array(s2.length + 1).fill(0);
   }
   for (let i = 1; i < s1.length + 1; i++) {
     for (let j = 1; j < s2.length + 1; j++) {


### PR DESCRIPTION
// 使用 dp 时，声明二维数组时应该为 dp[s1.length + 1][s2.length + 1]， 否则有边界条件没包括
如：longestCommonSequence("fo", "fisssssssss")
此时dp为：
[
 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
 [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NaN],
 [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, NaN]
]